### PR TITLE
feat: add tags to aws_api_gateway_rest_api

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,7 @@ resource "aws_api_gateway_rest_api" "default" {
     types = var.types
   }
   policy = var.api_policy
+  tags   = var.tags
 }
 
 # Module      : Api Gateway Resource


### PR DESCRIPTION
# Description

Tags variable was defined as an input but not used
in the resource that allows them.
