### PR TITLE
fix identity_source default value

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -252,7 +252,7 @@ resource "aws_api_gateway_authorizer" "default" {
   authorizer_uri                   = length(var.authorizer_uri) > 0 ? element(var.authorizer_uri, count.index) : ""
   authorizer_credentials           = length(var.authorizer_credentials) > 0 ? element(var.authorizer_credentials, count.index) : ""
   authorizer_result_ttl_in_seconds = length(var.authorizer_result_ttl_in_seconds) > 0 ? element(var.authorizer_result_ttl_in_seconds, count.index) : 300
-  identity_source                  = length(var.identity_sources) > 0 ? element(var.identity_sources, count.index) : ""
+  identity_source                  = length(var.identity_sources) > 0 ? element(var.identity_sources, count.index) : "method.request.header.Authorization"
   type                             = length(var.authorizer_types) > 0 ? element(var.authorizer_types, count.index) : "TOKEN"
   identity_validation_expression   = length(var.identity_validation_expressions) > 0 ? element(var.identity_validation_expressions, count.index) : ""
   provider_arns                    = length(var.provider_arns) > 0 ? element(var.provider_arns, count.index) : null


### PR DESCRIPTION
The default value for identity_source should be "method.request.header.Authorization". Currently this "" value causes an exception in Terraform with a message of a bad request input. This is not helpful since you do not know what is causing this problem when using the api_gateway_authorizer resource.

Source: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_authorizer#identity_source
