### PR TITLE
Use minimum version of aws provider instead of specific version

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.10.0"
+      version = ">= 3.10.0"
     }
   }
 }


### PR DESCRIPTION
## what
* Use minimum version of AWS provider instead of specific version

## why
* Pinning a specific version of the AWS provider breaks when using other modules with higher provider version requirements.