### PR TITLE
Added dynamic block for endpoint_configuration in main.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -29,9 +29,18 @@ resource "aws_api_gateway_rest_api" "default" {
   minimum_compression_size = var.minimum_compression_size
   api_key_source           = var.api_key_source
 
-  endpoint_configuration {
-    types            = var.types
-    vpc_endpoint_ids = var.vpc_endpoint_ids
+  dynamic "endpoint_configuration" {
+    for_each = var.types == "PRIVATE" ? toset([1]) : toset([])
+    content {
+      types            = var.types
+      vpc_endpoint_ids = var.vpc_endpoint_ids
+    }
+  }
+  dynamic "endpoint_configuration" {
+    for_each = var.types != "PRIVATE" ? toset([1]) : toset([])
+    content {
+      types            = var.types
+    }
   }
   policy = var.api_policy
   tags   = var.tags


### PR DESCRIPTION
Added dynamic block for endpoint_configuration as vpc_endpoint_ids is only supported for PRIVATE endpoint type.

## what
* Added dynamic block for endpoint_configuration in aws_api_gateway_rest_api.
* Two blocks were added - one with vpc_endpoint_ids parameter and one without.

## why
* The current version doesn't support endpoint types which are not "PRIVATE".
* Using dynamic block we can choose if the vpc_endpoint_ids parameter needs to be added or not.
* The parameter vpc_endpoint_ids doesn't take null values if specified in the module.

