### PR TITLE
Pass VPC endpoints conditionally. Fixes #24

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ resource "aws_api_gateway_rest_api" "default" {
 
   endpoint_configuration {
     types            = var.types
-    vpc_endpoint_ids = var.vpc_endpoint_ids
+    vpc_endpoint_ids = length(var.vpc_endpoint_ids) > 0 && var.vpc_endpoint_ids[0] != "" ? var.vpc_endpoint_ids : null
   }
   policy = var.api_policy
   tags   = var.tags


### PR DESCRIPTION
## what
vpc_endpoint_ids is now passed conditionally to the endpoint configuration of the REST API

## why
* At present, if this variable is not set, rerunning terraform apply gives this error: BadRequestException: VPCEndpoints can only be specified with PRIVATE apis.
* This change checks that VPC endpoint is not set to the default

## references
* https://github.com/clouddrove/terraform-aws-api-gateway/issues/24

There may be a better way to check the value, but this fix worked for me.
