### PR TITLE
bug fix on aws_api_gateway_vpc_link resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -278,7 +278,7 @@ resource "aws_api_gateway_vpc_link" "default" {
   count       = var.vpc_link_count > 0 ? var.vpc_link_count : 0
   name        = element(var.vpc_link_names, count.index)
   description = length(var.vpc_link_descriptions) > 0 ? element(var.vpc_link_descriptions, count.index) : ""
-  target_arns = element(var.target_arns, count.index)
+  target_arns = [element(var.target_arns, count.index)]
 }
 
 # Module      : Api Gateway Api Key


### PR DESCRIPTION
fix bug on aws_api_gateway_vpc_link: target_arns expected to be a list but string is applied

