### PR TITLE
added rest api policy and make api private

### DIFF
--- a/_example/basic/example.tf
+++ b/_example/basic/example.tf
@@ -12,6 +12,9 @@ module "api-gateway" {
   # Api Gateway Resource
   path_parts = ["mytestresource"]
 
+  ##endpoint_configuration
+  types = ["PRIVATE"]
+
   # Api Gateway Method
   method_enabled = true
   http_methods   = ["GET"]

--- a/_example/basic/example.tf
+++ b/_example/basic/example.tf
@@ -58,4 +58,28 @@ EOF
   # Api Gateway Stage
   stage_enabled = true
   stage_names   = ["qa"]
+  ## Api Policy
+
+  api_policy = data.aws_iam_policy_document.test.json
+
+}
+
+data "aws_iam_policy_document" "test" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions   = ["execute-api:Invoke"]
+    resources = [module.api-gateway.execution_arn]
+
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = ["123.123.123.123/32"]
+    }
+  }
 }

--- a/_example/complete/example.tf
+++ b/_example/complete/example.tf
@@ -83,4 +83,29 @@ EOF
   # Api Gateway Api Key
   key_count = 2
   key_names = ["test", "test1"]
+
+  ## Api Policy
+
+  api_policy = data.aws_iam_policy_document.test.json
+
+}
+
+data "aws_iam_policy_document" "test" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions   = ["execute-api:Invoke"]
+    resources = [module.api-gateway.execution_arn]
+
+    condition {
+      test     = "IpAddress"
+      variable = "aws:SourceIp"
+      values   = ["123.123.123.123/32"]
+    }
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -36,29 +36,10 @@ resource "aws_api_gateway_rest_api" "default" {
   tags   = var.tags
 }
 
-data "aws_iam_policy_document" "test" {
-  statement {
-    effect = "Allow"
-
-    principals {
-      type        = "AWS"
-      identifiers = ["*"]
-    }
-
-    actions   = ["execute-api:Invoke"]
-    resources = [join("", aws_api_gateway_rest_api.default.*.execution_arn)]
-
-    condition {
-      test     = "IpAddress"
-      variable = "aws:SourceIp"
-      values   = ["123.123.123.123/32"]
-    }
-  }
-}
 
 resource "aws_api_gateway_rest_api_policy" "test" {
   rest_api_id = join("", aws_api_gateway_rest_api.default.*.id)
-  policy      = data.aws_iam_policy_document.test.json
+  policy      = var.api_policy
 }
 
 # Module      : Api Gateway Resource


### PR DESCRIPTION
what
• added rest api policy and make api private.
why
• To make the api private, it was necessary to add an api policy.