### PR TITLE
feat: custome stage name and auto-deploy variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -99,8 +99,8 @@ resource "aws_apigatewayv2_stage" "default" {
   count = var.enabled && var.create_default_stage_enabled ? 1 : 0
 
   api_id      = aws_apigatewayv2_api.default[0].id
-  name        = format("%s-stage", module.labels.id)
-  auto_deploy = false
+  name        = var.stage_name != null ? var.stage_name : format("%s-stage", module.labels.id)
+  auto_deploy = var.auto_deploy
   dynamic "access_log_settings" {
     for_each = var.access_log_settings
     content {

--- a/variables.tf
+++ b/variables.tf
@@ -266,3 +266,15 @@ variable "passthrough_behavior" {
   default     = "WHEN_NO_MATCH"
   description = "Pass-through behavior for incoming requests based on the Content-Type header in the request, and the available mapping templates specified as the request_templates attribute. "
 }
+
+variable "stage_name" {
+  type        = string
+  default     = null
+  description = "Stage Name to be used, set to `$default` to use Invoke URL as your default webpage for lambda"
+}
+
+variable "auto_deploy" {
+  type        = bool
+  default     = false
+  description = "Set this to true to enable stage Auto Deployment"
+}


### PR DESCRIPTION
## what
- Custom stage name for API Gateway
- Remove hardcoded `auto_deploy` to use as per user requirement.