### PR TITLE
added vpc_endpoint_id to variables.tf

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -706,3 +706,8 @@ variable "rest_api_resource_policy" {
   default     = ""
   description = "(Optional) custom resource policy for private rest api."
 }
+
+variable "vpc_endpoint_id" {
+  description = "The ID of the VPC endpoint"
+  type        = string
+}


### PR DESCRIPTION
what

Added a missing declaration for the vpc_endpoint_id variable in the Terraform AWS API Gateway module.
Ensured that all references to var.vpc_endpoint_id in main.tf are now properly linked to a declared variable.
Improved module consistency by aligning variable usage and declarations.

--------------------------------------------------------------------------------------------------------------------------------------------------------------------------

why

Fixed a Terraform error: “No declaration found for 'var.vpc_endpoint_id'”, which was blocking plan/apply operations.
Ensures that the module can be used as intended, supporting VPC endpoint configuration.
Prevents runtime errors and improves the reliability of the infrastructure code.
references
[Terraform Docs: Input Variables](https://www.terraform.io/language/values/variables)
[Similar issue on StackOverflow](https://stackoverflow.com/questions/60812044/no-declaration-found-for-var-xxx-in-terraform)
closes #123 (replace with your actual Jira or issue number if applicable)